### PR TITLE
OTWO-1412

### DIFF
--- a/lib/scm/adapters/bzr/pull.rb
+++ b/lib/scm/adapters/bzr/pull.rb
@@ -11,12 +11,28 @@ module Scm::Adapters
 				run "mkdir -p '#{self.url}'"
 				run "rm -rf '#{self.url}'"
 				run "bzr branch '#{from.url}' '#{self.url}'"
+        clean_up_disk
 			else
 				run "cd '#{self.url}' && bzr revert && bzr pull --overwrite '#{from.url}'"
 			end
 
 			yield(1,1) if block_given? # Progress bar callback
 		end
+
+    def clean_up_disk
+      # Usually a `bzr upgrade` is unnecessary, but it's fatal to miss it when
+      # required. Because I don't know how to detect in advance whether we
+      # actually need it, we play it safe and always upgrade.
+      #
+      # Unfortunately, not only can we not know whether it is required,
+      # but the command fails and raises when the upgrade is not required.
+
+      begin
+			  run "cd '#{self.url}' && bzr upgrade"
+      rescue RuntimeError => e
+        raise unless e.message =~ /already at the most recent format/
+      end
+    end
 
 	end
 end


### PR DESCRIPTION
We can't know when it's required, but it's fatal to miss it, so we force a `bzr upgrade` after every pull.

This patch fixes the SlocJobs that crash with "Broken pipe" errors, as well as the SlocJobs that hang forever. Both of these problems are caused by local repositories that require a format upgrade.
