### PR TITLE
OTWO-2738 Bump up git version to 1.8.2 and fix nothing_to_commit check

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ shell.  In order to pass the unit tests, all three systems must be installed
 and on your path. Ohloh uses the following versions, and other versions are
 totally unsupported at this time:
 
-cvsnt 2.5.03
-svn 1.4.2
-git 1.6.0.4
-hg 1.1.2
+cvsnt 2.5.03  
+svn 1.4.2  
+git 1.8.2.1  
+hg 1.1.2  
 
 If you are using CVS instead of CVSNT, you can potentially try creating
 a shell alias or symlink mapping 'cvsnt' to 'cvs'.

--- a/lib/scm/adapters/git/commit_all.rb
+++ b/lib/scm/adapters/git/commit_all.rb
@@ -64,7 +64,7 @@ module Scm::Adapters
 
 		# True if there are pending changes to commit.
 		def anything_to_commit?
-			run("cd '#{self.url}' && git status | tail -1") =~ /nothing to commit / ? false : true
+			run("cd '#{self.url}' && git status | tail -1") =~ /nothing to commit/ ? false : true
 		end
 
 		# Ensures that the repository directory exists, and that the git database has been initialized.


### PR DESCRIPTION
With the updated Git client the status message pattern has changed
from 'nothing to commit *' to 'nothing to commit, *'.
So this fix will make our library to work across the older and newer versions.
