### PR TITLE
Avoid network timeout on large histories

### DIFF
--- a/lib/scm/adapters/svn_chain/chain.rb
+++ b/lib/scm/adapters/svn_chain/chain.rb
@@ -73,7 +73,7 @@ module Scm::Adapters
 
 		def first_commit(after=0)
 			@first_commit ||={} # Poor man's memoize
-			@first_commit[after] ||= Scm::Parsers::SvnXmlParser.parse(next_revision_xml(after)).first
+			@first_commit[after] ||= Scm::Parsers::SvnXmlParser.parse(next_revision_xml(after)).last
 		end
 
 		# Returns the first commit with a revision number greater than the provided revision number
@@ -88,7 +88,7 @@ module Scm::Adapters
 			# intensive method that should always succeed:
 			# receive the revisions in order and extract
 			# the last entry.
-			run(back_to_front) || Scm::Parsers::SvnXmlParser.parse(run(front_to_back)).last
+                        run("#{back_to_front} || #{front_to_back}")
 		end
 
 		# If the passed diff represents the wholesale movement of the entire


### PR DESCRIPTION
This change should avoid a reverse svn log failure connection timeout by pulling the log in order (and extracting the last entry).  This is only done if the reverse log fails in order to keep overhead low for most enlistments, but this should fix failures for a number of repositories that have a large revision history.
