### PR TITLE
Normalize_Branch_Name: Correct condition in recalc_branch_name

### DIFF
--- a/lib/scm/adapters/svn/misc.rb
+++ b/lib/scm/adapters/svn/misc.rb
@@ -35,10 +35,10 @@ module Scm::Adapters
 
 			if list.include? 'trunk/'
 				self.url = File.join(self.url, 'trunk')
-				self.branch_name = File.join(self.branch_name, 'trunk') if self.branch_name
+				self.branch_name = File.join(self.branch_name, 'trunk')
 			elsif list.size == 1 and list.first[-1..-1] == '/'
 				self.url = File.join(self.url, list.first[0..-2])
-				self.branch_name = File.join(self.branch_name, list.first[0..-2]) if self.branch_name
+				self.branch_name = File.join(self.branch_name, list.first[0..-2])
 				return restrict_url_to_trunk
 			end
 			self.url

--- a/test/unit/svn_validation_test.rb
+++ b/test/unit/svn_validation_test.rb
@@ -159,9 +159,18 @@ module Scm::Adapters
 				assert_equal '', svn_trunk.branch_name
 			end
 		end
-	end
 
-	def test_strip_trailing_whack_from_branch_name
-		assert_equal '/trunk', SvnAdapter.new(:branch_name => "/trunk/").normalize.branch_name
+    def test_strip_trailing_whack_from_branch_name
+      with_svn_repository('svn') do |svn|
+        assert_equal '/trunk', SvnAdapter.new(:url => svn.root, :branch_name => "/trunk/").normalize.branch_name
+      end
+    end
+
+    def test_empty_branch_name_with_file_system
+      Scm::ScratchDir.new do |dir|
+        svn = SvnAdapter.new(:url => dir).normalize
+        assert_equal '', svn.branch_name
+      end
+    end
 	end
 end


### PR DESCRIPTION
Remove unneeded check for @branch_name in svn/misc.rb

Handle file system based SVN URLs better
