### PR TITLE
OTWO-3236 Fix SVN Failing Jobs (SlocJob)

### DIFF
--- a/lib/scm/adapters/svn/cat_file.rb
+++ b/lib/scm/adapters/svn/cat_file.rb
@@ -12,7 +12,7 @@ module Scm::Adapters
 			begin
 				run "svn cat --trust-server-cert --non-interactive -r #{revision} '#{SvnAdapter.uri_encode(File.join(self.root, self.branch_name.to_s, path.to_s))}@#{revision}'"
 			rescue
-				raise unless $!.message =~ /svn:.*Could not cat all targets because some targets don't exist/
+				raise unless $!.message =~ /svn:.*Could not cat all targets because some targets (don't exist|are directories)/
 			end
 		end
 	end


### PR DESCRIPTION
- Recently when using svn 1.8.8 and encountering a new directory change
  the expection wasn't handled and it was returning a non-zero exit code
- Earlier in 1.6.6, it was returning 0 as exit code and hence it wasn't occuring
- Now, the exception message has been updated matching the regex
