### PR TITLE
OTWO-3248: Convert Ohloh SCM into a gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ hg 1.1.2
 If you are using CVS instead of CVSNT, you can potentially try creating
 a shell alias or symlink mapping 'cvsnt' to 'cvs'.
 
+## Usage with Bundler
+
+```
+gem 'ohloh_scm', git: 'https://github.com/blackducksw/ohloh_scm/', require: 'scm'
+```
 ## Running
 
 Ensure that cvsnt, svn, svnadmin, svnsync, git, and hg are all on your path. You'll also need to ensure that you have the xmloutput plugin installed for bazaar.

--- a/lib/scm/adapters/bzr/validation.rb
+++ b/lib/scm/adapters/bzr/validation.rb
@@ -1,7 +1,7 @@
 module Scm::Adapters
 	class BzrAdapter < AbstractAdapter
 		def self.url_regex
-			/^((((http|https|bzr|bzr\+ssh|file):\/\/((\w+@)?[A-Za-z0-9_\-\.]+(:\d+)?\/)?)|(lp:[A-Za-z0-9_\-\.\~])))?[A-Za-z0-9_\-\.\/\~\+]*$/
+			/^((((http|https|bzr|bzr\+ssh|file):\/\/((\w+@)?[A-Za-z0-9_\-\.]+(:\d+)?\/)?)|(lp:[A-Za-z0-9_\-\.\~])))?[A-Za-z0-9_@\-\.\/\~\+]*$/
 		end
 
 		def self.public_url_regex

--- a/lib/scm/adapters/git/validation.rb
+++ b/lib/scm/adapters/git/validation.rb
@@ -1,7 +1,7 @@
 module Scm::Adapters
 	class GitAdapter < AbstractAdapter
 		def self.url_regex
-			/^(http|https|rsync|git|ssh):\/\/(\w+@)?[A-Za-z0-9_\-\.]+(:\d+)?\/[A-Za-z0-9_\-\.\/\~\+]*$/
+			/^(http|https|rsync|git|ssh):\/\/(\w+@)?[A-Za-z0-9_\-\.]+(:\d+)?\/[A-Za-z0-9_@\-\.\/\~\+]*$/
 		end
 
 		def self.public_url_regex

--- a/lib/scm/adapters/hg/validation.rb
+++ b/lib/scm/adapters/hg/validation.rb
@@ -1,7 +1,7 @@
 module Scm::Adapters
 	class HgAdapter < AbstractAdapter
 		def self.url_regex
-			/^((http|https|ssh|file):\/\/((\w+@)?[A-Za-z0-9_\-\.]+(:\d+)?\/)?)?[A-Za-z0-9_\-\.\/\~\+]*$/
+			/^((http|https|ssh|file):\/\/((\w+@)?[A-Za-z0-9_\-\.]+(:\d+)?\/)?)?[A-Za-z0-9_@\-\.\/\~\+]*$/
 		end
 
 		def self.public_url_regex

--- a/lib/scm/adapters/svn/validation.rb
+++ b/lib/scm/adapters/svn/validation.rb
@@ -1,7 +1,7 @@
 module Scm::Adapters
 	class SvnAdapter < AbstractAdapter
 		def self.url_regex
-			/^(file|http|https|svn):\/\/(\/)?[A-Za-z0-9_\-\.]+(:\d+)?(\/[A-Za-z0-9_\-\.\/\+%^~ ]*)?$/
+			/^(file|http|https|svn):\/\/(\/)?[A-Za-z0-9_\-\.]+(:\d+)?(\/[A-Za-z0-9_@\-\.\/\+%^~ ]*)?$/
 		end
 
 		def self.public_url_regex

--- a/lib/scm/version.rb
+++ b/lib/scm/version.rb
@@ -1,0 +1,5 @@
+module Scm
+  module Version
+    STRING = '0.0.1'
+  end
+end

--- a/ohloh_scm.gemspec
+++ b/ohloh_scm.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+$:.push File.expand_path("../lib", __FILE__)
+require 'scm/version'
+
+Gem::Specification.new do |gem|
+  gem.name          = 'ohloh_scm'
+  gem.version       = Scm::Version::STRING
+  gem.authors       = ["BlackDuck Software"]
+  gem.email         = ["info@blackducksoftware.com"]
+  gem.summary       = %[Source Control Management]
+  gem.description   = %[The Ohloh source control management library]
+  gem.homepage      = %[https://github.com/blackducksw/ohloh_scm/]
+  gem.license       = %[GPL v2.0]
+
+  gem.files         = `git ls-files -z`.split("\x0")
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths = %w(lib)
+end


### PR DESCRIPTION
The function url_regex needs to match "@" in urls to support Ohloh's
tests. Since rvm gem paths will have gemset@ruby pattern, @ can be a
part of url for repositories inside this library's test folder.
