### PR TITLE
Darcs Support: Parses logs of newer version of darcs. Use hashes as tokens instead of patch names.

### DIFF
--- a/lib/ohloh_scm/adapters/darcs/cat_file.rb
+++ b/lib/ohloh_scm/adapters/darcs/cat_file.rb
@@ -10,7 +10,7 @@ module OhlohScm::Adapters
 		end
 
 		def cat(revision, path)
-			out, err = run_with_err("cd '#{url}' && darcs show contents -p '#{revision}' #{escape(path)}")
+			out, err = run_with_err("cd '#{url}' && darcs show contents -h '#{revision}' #{escape(path)}")
 			# show contents gives no error for non-existent paths
 			#return nil if err =~ /No such file in rev/
 			raise RuntimeError.new(err) unless err.to_s == ''

--- a/lib/ohloh_scm/adapters/darcs/commits.rb
+++ b/lib/ohloh_scm/adapters/darcs/commits.rb
@@ -2,19 +2,19 @@ module OhlohScm::Adapters
 	class DarcsAdapter < AbstractAdapter
 
 		# Return the number of commits in the repository following +since+.
-		def commit_count(since=nil)
-			commit_tokens(since).size
+		def commit_count(opts={})
+			commit_tokens(opts).size
 		end
 
 		# Return the list of commit tokens following +since+.
-		def commit_tokens(since=nil, up_to=nil)
-      from = since ? " --from-patch #{since}" : ""
-      to   = up_to ? " --to-patch #{up_to}" : ""
-			tokens = string_to_patch_names(run("cd '#{self.url}' && darcs changes#{from}#{to}")).reverse
+		def commit_tokens(opts={})
+			after = opts[:after] ? " --from-match 'hash #{opts[:after]}'" : ""
+			up_to = opts[:up_to] ? " --to-match 'hash #{opts[:up_to]}'" : ""
+			tokens = string_to_patch_tokens(run("cd '#{self.url}' && darcs changes#{after}#{up_to}")).reverse
 
 			# Darcs returns everything after *and including* since.
 			# We want to exclude it.
-			if tokens.any? && tokens.first == since
+			if tokens.any? && tokens.first == opts[:after]
 				tokens[1..-1]
 			else
 				tokens
@@ -25,11 +25,11 @@ module OhlohScm::Adapters
 		# Not including the diffs is meant to be a memory savings when we encounter massive repositories.
 		# If you need all commits including diffs, you should use the each_commit() iterator, which only holds one commit
 		# in memory at a time.
-		def commits(since=nil)
-			from = since ? " --from-patch #{since}" : ""
-			log = run("cd '#{self.url}' && darcs changes#{from} --reverse")
+		def commits(opts={})
+			after = opts[:after] ? " --from-match 'hash #{opts[:after]}'" : ""
+			log = run("cd '#{self.url}' && darcs changes#{after} --reverse")
 			a = OhlohScm::Parsers::DarcsParser.parse(log)
-			if a.any? && a.first.token == since
+			if a.any? && a.first.token == opts[:after]
 				a[1..-1]
 			else
 				a
@@ -38,7 +38,7 @@ module OhlohScm::Adapters
 
 		# Returns a single commit, including its diffs
 		def verbose_commit(token)
-			log = run("cd '#{self.url}' && darcs changes -v -p '#{token}'")
+			log = run("cd '#{self.url}' && darcs changes -v -h '#{token}'")
 			OhlohScm::Parsers::DarcsParser.parse(log).first
 		end
 
@@ -46,32 +46,33 @@ module OhlohScm::Adapters
 		# The log is stored in a temporary file.
 		# This is designed to prevent excessive RAM usage when we encounter a massive repository.
 		# Only a single commit is ever held in memory at once.
-		def each_commit(since=nil)
-			open_log_file(since) do |io|
+		def each_commit(opts={})
+			open_log_file(opts) do |io|
 				OhlohScm::Parsers::DarcsParser.parse(io) do |commit|
-					yield commit if block_given? && commit.token != since
+					yield commit if block_given? && commit.token != opts[:after]
 				end
 			end
 		end
 
 		# Not used by Ohloh proper, but handy for debugging and testing
-		def log(since=nil)
-      from = since ? " --from-patch #{since}" : ""
-			run "cd '#{url}' && darcs changes -s#{from}"
+		def log(opts={})
+      after = opts[:after] ? " --from-match 'hash #{opts[:after]}'" : ""
+			run "cd '#{url}' && darcs changes -s#{after}"
 		end
 
 		# Returns a file handle to the log.
 		# In our standard, the log should include everything AFTER +since+. However, darcs doesn't work that way;
 		# it returns everything after and INCLUDING +since+. Therefore, consumers of this file should check for
 		# and reject the duplicate commit.
-		def open_log_file(since=nil)
+		def open_log_file(opts={})
+			after = opts[:after] ? " --from-match 'hash #{opts[:after]}'" : ''
 			begin
-				if since == head_token # There are no new commits
+				if opts[:after] == head_token # There are no new commits
 					# As a time optimization, just create an empty file rather than fetch a log we know will be empty.
 					File.open(log_filename, 'w') { }
 				else
-          from = since ? " --from-patch #{since}" : ""
-					run "cd '#{url}' && darcs changes --reverse -v#{from} > #{log_filename}"
+					after = opts[:after] ? " --from-match 'hash #{opts[:after]}'" : ""
+					run "cd '#{url}' && darcs changes --reverse -v#{after} > #{log_filename}"
 				end
 				File.open(log_filename, 'r') { |io| yield io }
 			ensure

--- a/lib/ohloh_scm/adapters/darcs/head.rb
+++ b/lib/ohloh_scm/adapters/darcs/head.rb
@@ -1,7 +1,7 @@
 module OhlohScm::Adapters
 	class DarcsAdapter < AbstractAdapter
 		def head_token
-		  string_to_patch_names(run("cd '#{url}' && darcs changes --last 1"))[0]
+		  string_to_patch_tokens(run("cd '#{url}' && darcs changes --last 1"))[0]
 		end
 
 		def head
@@ -9,15 +9,15 @@ module OhlohScm::Adapters
 		end
 
 		def parent_tokens(commit)
-		  string_to_patch_names(run("cd '#{url}' && darcs changes --to-patch #{commit.token}"))[1..-1]
+		  string_to_patch_tokens(run("cd '#{url}' && darcs changes --to-match 'hash #{commit.token}'"))[1..-1]
 		end
 
 		def parents(commit)
 			parent_tokens(commit).map {|token| verbose_commit(token)}
 		end
 
-		def string_to_patch_names(s)
-		  s.split(/\n/).select {|s| s =~ /^  \* /}.map {|s| s.sub(/^  \* /,'')}
+		def string_to_patch_tokens(s)
+		  s.split(/\n/).select {|s| s =~ /^patch /}.map {|s| s.sub(/^patch /,'')}
 		end
 	end
 end

--- a/lib/ohloh_scm/adapters/darcs/misc.rb
+++ b/lib/ohloh_scm/adapters/darcs/misc.rb
@@ -10,11 +10,11 @@ module OhlohScm::Adapters
 		end
 
 		def ls_tree(token)
-			run("cd '#{path}' && darcs show files -p '#{token}'").split("\n")
+			run("cd '#{path}' && darcs show files --no-pending -h '#{token}'").split("\n")
 		end
 
 		def export(dest_dir, token=nil)
-			p = token ? " -p '#{token}'" : ""
+			p = token ? " -h '#{token}'" : ""
 			run("cd '#{path}' && darcs dist#{p} && mv darcs.tar.gz '#{dest_dir}'")
 		end
 	end

--- a/lib/ohloh_scm/adapters/darcs/patch.rb
+++ b/lib/ohloh_scm/adapters/darcs/patch.rb
@@ -1,7 +1,7 @@
 module OhlohScm::Adapters
   class DarcsAdapter < AbstractAdapter
     def patch_for_commit(commit)
-      run("cd '#{url}' && darcs changes -p'#{commit.token}' -v")
+      run("cd '#{url}' && darcs changes -h'#{commit.token}' -v")
     end
   end
 end

--- a/lib/ohloh_scm/commit.rb
+++ b/lib/ohloh_scm/commit.rb
@@ -34,7 +34,7 @@ module Scm
 		# For Git, the token is the commit SHA1 hash.
 		# For CVS, which does not support atomic commits with unique IDs, we use
 		# the approximate timestamp of the change.
-		# For Darcs, the token is the patch name, and it may not be unique. XXX
+		# For Darcs, the hash will be used as the token here.
 		attr_accessor :token
 
 		# A pointer back to the adapter that contains this commit.

--- a/lib/ohloh_scm/parsers/darcs_parser.rb
+++ b/lib/ohloh_scm/parsers/darcs_parser.rb
@@ -8,34 +8,37 @@ module OhlohScm::Parsers
 		def self.internal_parse(buffer, opts)
 			e = nil
 			state = :patch
+#			email_match = Regexp.new(Regexp.quote('/^(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){255,})(?!(?>(?1)"?(?>\\\[ -~]|[^"])"?(?1)){65,}@)((?>(?>(?>((?>(?>(?>\x0D\x0A)?[\x09 ])+|(?>[\x09 ]*\x0D\x0A)?[\x09 ]+)?)(\((?>(?2)(?>[\x01-\x08\x0B\x0C\x0E-\'*-\[\]-\x7F]|\\\[\x00-\x7F]|(?3)))*(?2)\)))+(?2))|(?2))?)([!#-\'*+\/-9=?^-~-]+|"(?>(?2)(?>[\x01-\x08\x0B\x0C\x0E-!#-\[\]-\x7F]|\\\[\x00-\x7F]))*(?2)")(?>(?1)\.(?1)(?4))*(?1)@(?!(?1)[a-z0-9-]{64,})(?1)(?>([a-z0-9](?>[a-z0-9-]*[a-z0-9])?)(?>(?1)\.(?!(?1)[a-z0-9-]{64,})(?1)(?5)){0,126}|\[(?:(?>IPv6:(?>([a-f0-9]{1,4})(?>:(?6)){7}|(?!(?:.*[a-f0-9][:\]]){8,})((?6)(?>:(?6)){0,6})?::(?7)?))|(?>(?>IPv6:(?>(?6)(?>:(?6)){5}:|(?!(?:.*[a-f0-9]:){6,})(?8)?::(?>((?6)(?>:(?6)){0,4}):)?))?(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(?>\.(?9)){3}))\])(?1)$/isD'))
 
 			buffer.each_line do |l|
 				#print "\n#{state}"
 				next_state = state
 				if state == :patch
 					case l
-					when /^([^ ]...........................)  (.*)$/
+					when /^patch ([0-9a-f]*)/
 						yield e if e && block_given?
 						e = Scm::Commit.new
-						e.author_date = Time.parse($1).utc
-						nameemail = $2
-						case nameemail
-						when /^([^<]*) <(.*)>$/
-						  e.author_name = $1
-						  e.author_email = $2
-						when /^([^@]*)$/
-						  e.author_name = $1
-						  e.author_email = nil
-						else
-						  e.author_name = nil
-						  e.author_email = nameemail
-						end
 						e.diffs = []
+						e.token = $1
+					when /^Author: (.*)/
+						nameemail = $1
+						case nameemail
+						when /^(\b.*) <([^>]*)>/
+							e.author_name = $1
+							e.author_email = $2
+						when /^([^@]*)$/
+							e.author_name = $1
+							e.author_email = nil
+						else
+							e.author_name = nil
+							e.author_email = nameemail
+						end
+					when /^Date:   ([^ ]...........................)/
+						e.author_date = Time.parse($1).utc
 					when /^  \* (.*)/
-						e.token = ($1 || '')
+						e.message = ($1 || '')
 						next_state = :long_comment_or_prims
 					end
-
 				elsif state == :long_comment_or_prims
 					case l
 					when /^    addfile\s+(.+)/

--- a/test/data/darcs_patch.diff
+++ b/test/data/darcs_patch.diff
@@ -1,4 +1,6 @@
-Wed Nov  3 15:49:53 PDT 2010  Simon Michael <simon@joyful.com>
+patch bd7e455d648b784ce4be2db26a4e62dfe734dd66
+Author: Simon Michael <simon@joyful.com>
+Date:   Wed Nov  3 18:49:53 EDT 2010
   * add helloworld.c
     addfile ./helloworld.c
     hunk ./helloworld.c 1

--- a/test/unit/darcs_cat_file_test.rb
+++ b/test/unit/darcs_cat_file_test.rb
@@ -21,9 +21,9 @@ main()
 EXPECTED
 
 				# The file was deleted by the "remove..." patch. Check that it does not exist now, but existed in parent.
-				assert_equal nil, darcs.cat_file(Scm::Commit.new(:token => 'remove helloworld.c'), Scm::Diff.new(:path => 'helloworld.c'))
-				assert_equal expected, darcs.cat_file_parent(Scm::Commit.new(:token => 'remove helloworld.c'), Scm::Diff.new(:path => 'helloworld.c'))
-				assert_equal expected, darcs.cat_file(Scm::Commit.new(:token => 'add helloworld.c'), Scm::Diff.new(:path => 'helloworld.c'))
+				assert_equal nil, darcs.cat_file(Scm::Commit.new(:token => '1007b5ad4831769283213d47e1fd5f6d30ac97f0'), Scm::Diff.new(:path => 'helloworld.c'))
+				assert_equal expected, darcs.cat_file_parent(Scm::Commit.new(:token => '1007b5ad4831769283213d47e1fd5f6d30ac97f0'), Scm::Diff.new(:path => 'helloworld.c'))
+				assert_equal expected, darcs.cat_file(Scm::Commit.new(:token => 'bd7e455d648b784ce4be2db26a4e62dfe734dd66'), Scm::Diff.new(:path => 'helloworld.c'))
 			end
 		end
 

--- a/test/unit/darcs_commits_test.rb
+++ b/test/unit/darcs_commits_test.rb
@@ -6,17 +6,17 @@ module OhlohScm::Adapters
 		def test_commit
 			with_darcs_repository('darcs') do |darcs|
 				assert_equal 2, darcs.commit_count
-				assert_equal 1, darcs.commit_count('add helloworld.c')
-				assert_equal 0, darcs.commit_count('remove helloworld.c')
-				assert_equal ['add helloworld.c', 'remove helloworld.c'], darcs.commit_tokens
-				assert_equal ['remove helloworld.c'], darcs.commit_tokens('add helloworld.c')
-				assert_equal [], darcs.commit_tokens('remove helloworld.c')
-				assert_equal ['add helloworld.c',
-											'remove helloworld.c'], darcs.commits.collect { |c| c.token }
-				assert_equal ['remove helloworld.c'], darcs.commits('add helloworld.c').collect { |c| c.token }
+				assert_equal 1, darcs.commit_count(:after => 'bd7e455d648b784ce4be2db26a4e62dfe734dd66')
+				assert_equal 0, darcs.commit_count(:after => '1007b5ad4831769283213d47e1fd5f6d30ac97f0')
+				assert_equal ['bd7e455d648b784ce4be2db26a4e62dfe734dd66', '1007b5ad4831769283213d47e1fd5f6d30ac97f0'], darcs.commit_tokens
+				assert_equal ['1007b5ad4831769283213d47e1fd5f6d30ac97f0'], darcs.commit_tokens(:after => 'bd7e455d648b784ce4be2db26a4e62dfe734dd66')
+				assert_equal [], darcs.commit_tokens(:after => '1007b5ad4831769283213d47e1fd5f6d30ac97f0')
+				assert_equal ['bd7e455d648b784ce4be2db26a4e62dfe734dd66',
+											'1007b5ad4831769283213d47e1fd5f6d30ac97f0'], darcs.commits.collect { |c| c.token }
+				assert_equal ['1007b5ad4831769283213d47e1fd5f6d30ac97f0'], darcs.commits(:after => 'bd7e455d648b784ce4be2db26a4e62dfe734dd66').collect { |c| c.token }
 				# Check that the diffs are not populated
-				assert_equal [], darcs.commits('add helloworld.c').first.diffs
-				assert_equal [], darcs.commits('remove helloworld.c')
+				assert_equal [], darcs.commits(:after => 'bd7e455d648b784ce4be2db26a4e62dfe734dd66').first.diffs
+				assert_equal [], darcs.commits(:after => '1007b5ad4831769283213d47e1fd5f6d30ac97f0')
 			end
 		end
 
@@ -37,8 +37,8 @@ module OhlohScm::Adapters
 				assert !FileTest.exist?(darcs.log_filename) # Make sure we cleaned up after ourselves
 
 				# Verify that we got the commits in forward chronological order
-				assert_equal ['add helloworld.c',
-											'remove helloworld.c'], commits.map {|c| c.token}
+				assert_equal ['bd7e455d648b784ce4be2db26a4e62dfe734dd66',
+											'1007b5ad4831769283213d47e1fd5f6d30ac97f0'], commits.map {|c| c.token}
 			end
 		end
 	end

--- a/test/unit/darcs_head_test.rb
+++ b/test/unit/darcs_head_test.rb
@@ -5,11 +5,11 @@ module OhlohScm::Adapters
 
 		def test_head_and_parents
 			with_darcs_repository('darcs') do |darcs|
-				assert_equal 'remove helloworld.c', darcs.head_token
-				assert_equal 'remove helloworld.c', darcs.head.token
+				assert_equal '1007b5ad4831769283213d47e1fd5f6d30ac97f0', darcs.head_token
+				assert_equal '1007b5ad4831769283213d47e1fd5f6d30ac97f0', darcs.head.token
 				assert darcs.head.diffs.any? # diffs should be populated
 
-				assert_equal 'add helloworld.c', darcs.parents(darcs.head).first.token
+				assert_equal 'bd7e455d648b784ce4be2db26a4e62dfe734dd66', darcs.parents(darcs.head).first.token
 				assert darcs.parents(darcs.head).first.diffs.any?
 			end
 		end

--- a/test/unit/darcs_misc_test.rb
+++ b/test/unit/darcs_misc_test.rb
@@ -14,14 +14,14 @@ module OhlohScm::Adapters
 
 		def test_ls_tree
 			with_darcs_repository('darcs') do |darcs|
-				assert_equal ['.','./helloworld.c'], darcs.ls_tree('add helloworld.c').sort
+				assert_equal ['.','./helloworld.c'], darcs.ls_tree('bd7e455d648b784ce4be2db26a4e62dfe734dd66').sort
 			end
 		end
 
 		def test_export
 			with_darcs_repository('darcs') do |darcs|
 				Scm::ScratchDir.new do |dir|
-					darcs.export(dir, 'add helloworld.c')
+					darcs.export(dir, 'bd7e455d648b784ce4be2db26a4e62dfe734dd66')
 					assert_equal ['.', '..', 'darcs.tar.gz'], Dir.entries(dir).sort
 				end
 			end

--- a/test/unit/darcs_parser_test.rb
+++ b/test/unit/darcs_parser_test.rb
@@ -9,12 +9,15 @@ module OhlohScm::Parsers
 
 		def test_log_parser_default
 sample_log = <<SAMPLE
-Wed Nov  3 15:55:25 PDT 2010  Simon Michael <simon@joyful.com>
+patch 1007b5ad4831769283213d47e1fd5f6d30ac97f0
+Author: Simon Michael <simon@joyful.com>
+Date:   Wed Nov  3 18:55:25 EDT 2010
   * remove helloworld.c
 
-Wed Nov  3 15:49:53 PDT 2010  Simon Michael <simon@joyful.com>
+patch bd7e455d648b784ce4be2db26a4e62dfe734dd66
+Author: Simon Michael <simon@joyful.com>
+Date:   Wed Nov  3 18:49:53 EDT 2010
   * add helloworld.c
-
 SAMPLE
 
 			commits = DarcsParser.parse(sample_log)
@@ -22,29 +25,32 @@ SAMPLE
 			assert commits
 			assert_equal 2, commits.size
 
-			assert_equal 'remove helloworld.c', commits[0].token
+			assert_equal '1007b5ad4831769283213d47e1fd5f6d30ac97f0', commits[0].token
 			assert_equal 'Simon Michael', commits[0].author_name
 			assert_equal 'simon@joyful.com', commits[0].author_email
-			assert_equal nil, commits[0].message # Note \n at end of comment
+			assert_equal 'remove helloworld.c', commits[0].message # Note \n at end of comment
 			assert_equal Time.utc(2010,11,3,22,55,25), commits[0].author_date
 			assert_equal 0, commits[0].diffs.size
 
-			assert_equal 'add helloworld.c', commits[1].token
+			assert_equal 'bd7e455d648b784ce4be2db26a4e62dfe734dd66', commits[1].token
 			assert_equal 'Simon Michael', commits[1].author_name
 			assert_equal 'simon@joyful.com', commits[1].author_email
-			assert_equal nil, commits[1].message # Note \n at end of comment
+			assert_equal 'add helloworld.c', commits[1].message # Note \n at end of comment
 			assert_equal Time.utc(2010,11,3,22,49,53), commits[1].author_date
 			assert_equal 0, commits[1].diffs.size
 		end
 
 		def test_log_parser_default_partial_user_name
 sample_log = <<SAMPLE
-Wed Nov  3 15:55:25 PDT 2010  Simon Michael
+patch 1007b5ad4831769283213d47e1fd5f6d30ac97f0
+Author: Simon Michael
+Date:   Wed Nov  3 18:55:25 EDT 2010
   * name only
 
-Wed Nov  3 15:49:53 PDT 2010  simon@joyful.com
+patch bd7e455d648b784ce4be2db26a4e62dfe734dd66
+Author: simon@joyful.com
+Date:   Wed Nov  3 18:49:53 EDT 2010
   * email only
-
 SAMPLE
 
 			commits = DarcsParser.parse(sample_log)
@@ -52,18 +58,20 @@ SAMPLE
 			assert commits
 			assert_equal 2, commits.size
 
-			assert_equal 'name only', commits[0].token
+			assert_equal '1007b5ad4831769283213d47e1fd5f6d30ac97f0', commits[0].token
 			assert_equal 'Simon Michael', commits[0].author_name
-			assert !commits[0].author_email
+			assert_nil commits[0].author_email
 
-			assert_equal 'email only', commits[1].token
-			assert !commits[1].author_name
+			assert_equal 'bd7e455d648b784ce4be2db26a4e62dfe734dd66', commits[1].token
+			assert_nil commits[1].author_name
 			assert_equal 'simon@joyful.com', commits[1].author_email
 		end
 
 		def test_log_parser_verbose
 sample_log = <<SAMPLE
-Wed Nov  3 15:55:25 PDT 2010  Simon Michael <simon@joyful.com>
+patch 1007b5ad4831769283213d47e1fd5f6d30ac97f0
+Author: Simon Michael <simon@joyful.com>
+Date:   Wed Nov  3 18:55:25 EDT 2010
   * remove helloworld.c
     hunk ./helloworld.c 1
     -/* Hello, World! */
@@ -80,7 +88,9 @@ Wed Nov  3 15:55:25 PDT 2010  Simon Michael <simon@joyful.com>
     -}
     rmfile ./helloworld.c
 
-Wed Nov  3 15:49:53 PDT 2010  Simon Michael <simon@joyful.com>
+patch bd7e455d648b784ce4be2db26a4e62dfe734dd66
+Author: Simon Michael <simon@joyful.com>
+Date:   Wed Nov  3 18:49:53 EDT 2010
   * add helloworld.c
     addfile ./helloworld.c
     hunk ./helloworld.c 1
@@ -103,19 +113,19 @@ SAMPLE
 			assert commits
 			assert_equal 2, commits.size
 
-			assert_equal 'remove helloworld.c', commits[0].token
+			assert_equal '1007b5ad4831769283213d47e1fd5f6d30ac97f0', commits[0].token
 			assert_equal 'Simon Michael', commits[0].author_name
 			assert_equal 'simon@joyful.com', commits[0].author_email
-			assert_equal nil, commits[0].message # Note \n at end of comment
+			assert_equal 'remove helloworld.c', commits[0].message # Note \n at end of comment
 			assert_equal Time.utc(2010,11,3,22,55,25), commits[0].author_date
 			assert_equal 2, commits[0].diffs.size
 			assert_equal './helloworld.c', commits[0].diffs[0].path
 			assert_equal './helloworld.c', commits[0].diffs[1].path
 
-			assert_equal 'add helloworld.c', commits[1].token
+			assert_equal 'bd7e455d648b784ce4be2db26a4e62dfe734dd66', commits[1].token
 			assert_equal 'Simon Michael', commits[1].author_name
 			assert_equal 'simon@joyful.com', commits[1].author_email
-			assert_equal nil, commits[1].message # Note \n at end of comment
+			assert_equal 'add helloworld.c', commits[1].message # Note \n at end of comment
 			assert_equal Time.utc(2010,11,3,22,49,53), commits[1].author_date
 			assert_equal 2, commits[0].diffs.size
 			assert_equal './helloworld.c', commits[0].diffs[0].path

--- a/test/unit/darcs_patch_test.rb
+++ b/test/unit/darcs_patch_test.rb
@@ -4,7 +4,7 @@ module OhlohScm::Adapters
   class DarcsPatchTest < OhlohScm::Test
     def test_patch_for_commit
       with_darcs_repository('darcs') do |repo|
-        commit = repo.verbose_commit('add helloworld.c')
+        commit = repo.verbose_commit('bd7e455d648b784ce4be2db26a4e62dfe734dd66')
         data = File.read(File.join(DATA_DIR, 'darcs_patch.diff'))
         assert_equal data, repo.patch_for_commit(commit)
       end

--- a/test/unit/darcs_pull_test.rb
+++ b/test/unit/darcs_pull_test.rb
@@ -17,7 +17,7 @@ module OhlohScm::Adapters
 
 					# Commit some new code on the original and pull again
 					src.run "cd '#{src.url}' && touch foo && darcs add foo && darcs record -a -m test"
-					assert_equal "test", src.commits.last.token
+					assert_equal "test", src.commits.last.message
 
 					dest.pull(src)
 					assert_equal src.log, dest.log

--- a/test/unit/darcs_push_test.rb
+++ b/test/unit/darcs_push_test.rb
@@ -47,7 +47,7 @@ module OhlohScm::Adapters
 
 					# Commit some new code on the original and pull again
 					src.run "cd '#{src.url}' && touch foo && darcs add foo && darcs record -a -m test"
-					assert_equal "test", src.commits.last.token
+					assert_equal "test", src.commits.last.message
 
 					src.push(dest)
 					assert_equal src.log, dest.log

--- a/test/unit/darcs_rev_list_test.rb
+++ b/test/unit/darcs_rev_list_test.rb
@@ -10,16 +10,44 @@ module OhlohScm::Adapters
 		def test_rev_list
 			with_darcs_repository('darcs_walk') do |darcs|
 				# Full history to a commit
-				assert_equal ["A"],                 darcs.commit_tokens(nil, "A")
-				assert_equal ["A","B"],             darcs.commit_tokens(nil, "B")
-				assert_equal ["A","B","C","D","E"], darcs.commit_tokens(nil, "E")
-				assert_equal ["A","B","C","D","E"], darcs.commit_tokens(nil, nil)
+				assert_equal [:A],                 rev_list_helper(darcs, nil, :A)
+				assert_equal [:A, :B],             rev_list_helper(darcs, nil, :B)
+				assert_equal [:A, :B, :C, :D, :E], rev_list_helper(darcs, nil, :E)
+				assert_equal [:A, :B, :C, :D, :E], rev_list_helper(darcs, nil, nil)
 
 				# # Limited history from one commit to another
-				assert_equal [],            darcs.commit_tokens("A", "A")
-				assert_equal ["B"],         darcs.commit_tokens("A", "B")
-				assert_equal ["B","C","D"], darcs.commit_tokens("A", "D")
+				assert_equal [],           rev_list_helper(darcs, :A, :A)
+				assert_equal [:B],         rev_list_helper(darcs, :A, :B)
+				assert_equal [:B, :C, :D], rev_list_helper(darcs, :A, :D)
 			end
+		end
+
+		protected
+
+		def rev_list_helper(darcs, from, to)
+			to_labels(darcs.commit_tokens(:after => from_label(from), :up_to => from_label(to)))
+		end
+
+		def commit_labels
+			{ '25b46d61afa639f268c929e6259f1271b7a43d6f' => :A,
+				'7a1b8ed05d56b7099a2c16157ec7a947bcab9c9a' => :B,
+				'd50ee74be0f34fed3e23ec90346976024de40962' => :C,
+				'48dac48b9d5543895c409e81de18ff077f4dc1c3' => :D,
+				'3dbdfd7313c96379fd8a3ca4e6ebaf1bd12d46ae' => :E
+			}
+		end
+
+		def to_label(sha1)
+			commit_labels[sha1.to_s]
+		end
+
+		def to_labels(sha1s)
+			sha1s.collect { |sha1| to_label(sha1) }
+		end
+
+		def from_label(l)
+			commit_labels.each_pair { |k,v| return k if v.to_s == l.to_s }
+			nil
 		end
 	end
 end


### PR DESCRIPTION
I have modernized the darcs_support a bit and now it parses log files of current versions of darcs (tested with darcs-screened). I have also switched to hashes because they are more precise.

All darcs tests pass now except for one:

      5) Failure:
    test_cat_file(OhlohScm::Adapters::DarcsCatFileTest) [/home/andreas/repo/ohloh_scm/test/unit/darcs_cat_file_test.rb:25]:
    <"/* Hello, World! */\n\n/*\n * This file is not covered by any license, especially not\n * the GNU General Public License (GPL). Have fun!\n */\n\n#include <stdio.h>\nmain()\n{\n\tprintf(\"Hello, World!\\\\n\");\n}\n"> expected but was
    <nil>.

I think the problem is here:

    lib/ohloh_scm/adapters/darcs/cat_file.rb:			out, err = run_with_err("cd '#{url}' && darcs show contents -h '#{revision}' #{escape(path)}")

When I remove a file from a darcs repo and then run `darcs show contents -h <hash> <file>` on a revision that *did have* the `<file>` I get nothing. This may be a problem with darcs (?)

blackducksw/ohloh_scm#10