### PR TITLE
Fix for file descriptor leaks

### DIFF
--- a/lib/ohloh_scm/adapters/bzrlib/bzrlib_pipe_client.rb
+++ b/lib/ohloh_scm/adapters/bzrlib/bzrlib_pipe_client.rb
@@ -6,7 +6,7 @@ class BzrPipeClient
     @repository_url = repository_url
     @py_script = File.dirname(__FILE__) + '/bzrlib_pipe_server.py'
   end
-  
+
   def start
     @pid, @stdin, @stdout, @stderr = POSIX::Spawn::popen4 "python #{@py_script}"
     open_repository
@@ -27,8 +27,9 @@ class BzrPipeClient
     # send the command
     @stdin.puts cmd
     @stdin.flush
+    return if cmd == "QUIT"
 
-    # get status on stderr, first letter indicates state, 
+    # get status on stderr, first letter indicates state,
     # remaing value indicates length of the file content
     status = @stderr.read(10)
     flag = status[0,1]
@@ -46,6 +47,7 @@ class BzrPipeClient
 
   def shutdown
     send_command("QUIT")
+    [@stdout, @stdin, @stderr].each { |io| io.close unless io.closed? }
     Process.waitpid(@pid, Process::WNOHANG)
   end
 end

--- a/lib/ohloh_scm/adapters/bzrlib_adapter.rb
+++ b/lib/ohloh_scm/adapters/bzrlib_adapter.rb
@@ -5,13 +5,13 @@ module OhlohScm::Adapters
 	class BzrlibAdapter < BzrAdapter
 
     def setup
-      @bzr_client = BzrPipeClient.new(url)
-      @bzr_client.start
+      bzr_client = BzrPipeClient.new(url)
+      bzr_client.start
+      bzr_client
     end
 
     def bzr_client
-      setup unless @bzr_client
-      return @bzr_client
+      @bzr_client ||= setup
     end
 
     def cleanup

--- a/lib/ohloh_scm/adapters/hglib/client.rb
+++ b/lib/ohloh_scm/adapters/hglib/client.rb
@@ -36,6 +36,7 @@ class HglibClient
     # send the command
     @stdin.puts cmd
     @stdin.flush
+    return if cmd == "QUIT"
 
     # get status on stderr, first letter indicates state,
     # remaing value indicates length of the file content
@@ -55,6 +56,7 @@ class HglibClient
 
   def shutdown
     send_command("QUIT")
+    [@stdout, @stdin, @stderr].each { |io| io.close unless io.closed? }
     Process.waitpid(@pid, Process::WNOHANG)
   end
 end


### PR DESCRIPTION
This will fix the IOExceptions (Too many open files issue) and also avoids the large list of file descriptors that grows continually (detected via _lsof_ on UNIX). 

Please refer the attached screenshots for more clarity.

**File descriptor leaks before fix**

![file_descriptors_leaked](https://cloud.githubusercontent.com/assets/13594217/15493168/c810c3c4-219f-11e6-94d1-05932fbdd8c0.png)

**File descriptors after fix**

![file_descriptors_closed](https://cloud.githubusercontent.com/assets/13594217/15493243/4e31a950-21a0-11e6-8a7e-5ee6174af76d.png)