### PR TITLE
OTWO-4566: Add tags method to AbstractAdapter for api consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 pkg/
 *.cache
+.byebug*

--- a/lib/ohloh_scm/adapters/abstract/misc.rb
+++ b/lib/ohloh_scm/adapters/abstract/misc.rb
@@ -1,9 +1,13 @@
 module OhlohScm::Adapters
-	class AbstractAdapter
+  class AbstractAdapter
 
-		def is_merge_commit?(commit)
-			false
-		end
+    def is_merge_commit?(commit)
+      false
+    end
 
-	end
+    def tags
+      []
+    end
+
+  end
 end

--- a/lib/ohloh_scm/version.rb
+++ b/lib/ohloh_scm/version.rb
@@ -1,5 +1,5 @@
 module OhlohScm
   module Version
-    STRING = '2.2.5'
+    STRING = '2.2.6'
   end
 end


### PR DESCRIPTION
This lets the tests to support OTWO-4566 pass when using the Abstract Adapter