### PR TITLE
exist? must rely on raising exceptions like in v2

### DIFF
--- a/lib/ohloh_scm/status.rb
+++ b/lib/ohloh_scm/status.rb
@@ -12,9 +12,10 @@ module OhlohScm
     end
 
     def exist?
-      return unless scm_dir_exist?
-
       !activity.head_token.to_s.empty?
+    rescue RuntimeError
+      logger.debug { $ERROR_INFO.inspect }
+      false
     end
 
     def scm_dir_exist?

--- a/lib/ohloh_scm/validation.rb
+++ b/lib/ohloh_scm/validation.rb
@@ -20,9 +20,7 @@ module OhlohScm
 
     private
 
-    def validate_server_connection
-      return unless valid?
-    end
+    def validate_server_connection; end
 
     # rubocop:disable Metrics/AbcSize
     def validate_attributes

--- a/lib/ohloh_scm/version.rb
+++ b/lib/ohloh_scm/version.rb
@@ -2,7 +2,7 @@
 
 module OhlohScm
   module Version
-    STRING = '3.0.1'
+    STRING = '3.0.2'
     GIT = '2.17.1'
     SVN = '1.9.7'
     CVSNT = '2.5.04'

--- a/spec/ohloh_scm/bzr/scm_spec.rb
+++ b/spec/ohloh_scm/bzr/scm_spec.rb
@@ -7,9 +7,10 @@ describe 'Bzr::Scm' do
     with_bzr_repository('bzr') do |src|
       tmpdir do |dest_dir|
         core = OhlohScm::Factory.get_core(scm_type: :bzr, url: dest_dir)
-        refute core.status.exist?
+        refute core.status.scm_dir_exist?
 
         core.scm.pull(src.scm, TestCallback.new)
+        assert core.status.scm_dir_exist?
         assert core.status.exist?
       end
     end

--- a/spec/ohloh_scm/git/scm_spec.rb
+++ b/spec/ohloh_scm/git/scm_spec.rb
@@ -5,9 +5,10 @@ describe 'Git::Scm' do
     with_git_repository('git') do |src_core|
       tmpdir do |dest_dir|
         core = OhlohScm::Factory.get_core(scm_type: :git, url: dest_dir)
-        refute core.status.exist?
+        refute core.status.scm_dir_exist?
 
         core.scm.pull(src_core.scm, TestCallback.new)
+        assert core.status.scm_dir_exist?
         assert core.status.exist?
       end
     end
@@ -19,7 +20,7 @@ describe 'Git::Scm' do
     with_git_repository('git_with_multiple_branch', 'test') do |src_core|
       tmpdir do |dest_dir|
         core = OhlohScm::Factory.get_core(scm_type: :git, url: dest_dir, branch_name: 'test')
-        refute core.status.exist?
+        refute core.status.scm_dir_exist?
         core.scm.pull(src_core.scm, TestCallback.new)
 
         remote_master_branch_sha = `cd #{dest_dir} && git rev-parse origin/master`
@@ -36,8 +37,9 @@ describe 'Git::Scm' do
     with_cvs_repository('cvs', 'simple') do |src_core|
       tmpdir do |dest_dir|
         core = OhlohScm::Factory.get_core(scm_type: :git, url: dest_dir)
-        refute core.status.exist?
+        refute core.status.scm_dir_exist?
         core.scm.pull(src_core.scm, TestCallback.new)
+        assert core.status.scm_dir_exist?
         assert core.status.exist?
 
         dest_commits = core.activity.commits

--- a/spec/ohloh_scm/git/validation_spec.rb
+++ b/spec/ohloh_scm/git/validation_spec.rb
@@ -1,12 +1,6 @@
 require 'spec_helper'
 
 describe 'Git::Validation' do
-  it 'must handle non existent remote source' do
-    core = OhlohScm::Factory.get_core(scm_type: :git, url: 'https://github.com/Person/foobar')
-    core.validate
-    core.errors.wont_be :empty?
-  end
-
   it 'wont have errors for valid url' do
     core = OhlohScm::Factory.get_core(scm_type: :git, url: 'https://github.com/ruby/ruby')
     core.validation.send(:validate_attributes)


### PR DESCRIPTION
The exist? method version 2 relied upon purposefully raising exceptions
to indicate that a repository is missing. In v3 we tried to replace this
with a check for scm_dir(.git, .hg etc) instead. However we now realize
that exist? needs also to work for remote urls. So we are reverting back
to the ohloh_scm v2 logic:

https://github.com/blackducksoftware/ohloh_scm/blob/v2.5.1/lib/ohloh_scm/adapters/git/misc.rb#L7