### PR TITLE
OTWO-6505 Use remote bzr url for new repo validation

### DIFF
--- a/lib/ohloh_scm/bzr/activity.rb
+++ b/lib/ohloh_scm/bzr/activity.rb
@@ -75,8 +75,7 @@ module OhlohScm
       end
 
       def head_token
-        run("cd '#{url}' && bzr log --limit 1 --show-id #{url} 2> /dev/null"\
-              " | grep ^revision-id | cut -f2 -d' '").strip
+        run("bzr log --limit 1 --show-id #{url} 2> /dev/null | grep ^revision-id | cut -f2 -d' '").strip
       end
 
       def head

--- a/lib/ohloh_scm/version.rb
+++ b/lib/ohloh_scm/version.rb
@@ -2,7 +2,7 @@
 
 module OhlohScm
   module Version
-    STRING = '3.0.14'
+    STRING = '3.0.15'
     GIT = '2.17.1'
     SVN = '1.9.7'
     CVSNT = '2.5.04'


### PR DESCRIPTION
New repo is validated using status.exist? -> head_token.
We use remote urls for other SCMs as well.
This line is unchanged since OhlohScm migration in a1d1040.